### PR TITLE
add support for ELECTRON_VERSION

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -1,6 +1,15 @@
 var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+// Tweak to pick correct binding_path when running under an electron forked process.
+// If this PR gets merged, it will no longer be necessary.
+//   https://github.com/mapbox/node-pre-gyp/pull/343
+var binding_options = {};
+if (process.env.ELECTRON_VERSION) {
+  binding_options.runtime = 'electron';
+  binding_options.target = process.env.ELECTRON_VERSION;
+}
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')),
+                               binding_options);
 var binding = require(binding_path);
 var sqlite3 = module.exports = exports = binding;
 var EventEmitter = require('events').EventEmitter;

--- a/test/electron.test.js
+++ b/test/electron.test.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+describe('electron', function() {
+  it('respects ELECTRON_VERSION', function() {
+    process.env.ELECTRON_VERSION = '1.2.3';
+    assert.throws(function() { require('..'); },
+                  (/Cannot find module .*\/node-sqlite3\/lib\/binding\/electron-v1.2-[^-]+-x64\/node_sqlite3.node/));
+  });
+});


### PR DESCRIPTION
When forking from an electron process, the logic in node-pre-gyp
isn't quite right for finding the sqlite3 binary.  There's a PR
up to fix this [1].  In the meantime, this patches node-sqlite3
to respect an ELECTRON_VERSION environment variable, overriding
node-pre-gyp's options when that variable is detected.