### PR TITLE
Fixed testing on linux, readme, electron test

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,16 @@ In the case of MacOS with Homebrew, the command should look like the following:
 
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 
-# Testing
+# Testing (updated for marshalling)
 
 [mocha](https://github.com/visionmedia/mocha) is required to run unit tests.
 
 In sqlite3's directory (where its `package.json` resides) run the following:
 
     npm install mocha
+    npm run rebuild-tests #rebuilds marshal hooks
     npm test
+
 
 # Contributors
 

--- a/test/cpp/binding.gyp
+++ b/test/cpp/binding.gyp
@@ -8,8 +8,11 @@
     },
   "targets": [
     {
-        "target_name" : "marshal"
-      , "sources"     : [ "marshal.cc" ]
+        "target_name" : "marshal",
+        "conditions" : [
+            ["OS=='linux'", {"libraries+": ["../../../build/<(PRODUCT_DIR)/node_sqlite3.node"] } ]
+        ],
+        "sources"     : [ "marshal.cc" ]
     }
 ]}
 

--- a/test/cpp/binding.gyp
+++ b/test/cpp/binding.gyp
@@ -3,15 +3,14 @@
     {
         "cflags" : ["-Wall", "-Wextra", "-Wno-unused-parameter"],
         "defines": [ "V8_DEPRECATION_WARNINGS=1" ],
-        "libraries": [ "../../../build/<(PRODUCT_DIR)/node_sqlite3.node" ],
+        "conditions" : [
+            ["OS=='linux'", {"libraries+": ["../../../build/<(PRODUCT_DIR)/node_sqlite3.node"] } ]
+        ],
         "include_dirs": ["<!(node -e \"require('../..')\")", "<!(node -e \"require('nan')\")"],
     },
   "targets": [
     {
         "target_name" : "marshal",
-        "conditions" : [
-            ["OS=='linux'", {"libraries+": ["../../../build/<(PRODUCT_DIR)/node_sqlite3.node"] } ]
-        ],
         "sources"     : [ "marshal.cc" ]
     }
 ]}

--- a/test/cpp/binding.gyp
+++ b/test/cpp/binding.gyp
@@ -3,6 +3,7 @@
     {
         "cflags" : ["-Wall", "-Wextra", "-Wno-unused-parameter"],
         "defines": [ "V8_DEPRECATION_WARNINGS=1" ],
+        "libraries": [ "../../../build/Release/node_sqlite3.node" ],
         "include_dirs": ["<!(node -e \"require('../..')\")", "<!(node -e \"require('nan')\")"],
     },
   "targets": [

--- a/test/cpp/binding.gyp
+++ b/test/cpp/binding.gyp
@@ -3,7 +3,7 @@
     {
         "cflags" : ["-Wall", "-Wextra", "-Wno-unused-parameter"],
         "defines": [ "V8_DEPRECATION_WARNINGS=1" ],
-        "libraries": [ "../../../build/Release/node_sqlite3.node" ],
+        "libraries": [ "../../../build/<(PRODUCT_DIR)/node_sqlite3.node" ],
         "include_dirs": ["<!(node -e \"require('../..')\")", "<!(node -e \"require('nan')\")"],
     },
   "targets": [

--- a/test/electron.test.js
+++ b/test/electron.test.js
@@ -3,7 +3,11 @@ var assert = require('assert');
 describe('electron', function() {
   it('respects ELECTRON_VERSION', function() {
     process.env.ELECTRON_VERSION = '1.2.3';
+    let name = require.resolve('..');
+    delete require.cache[name];
+
     assert.throws(function() { require('..'); },
-                  (/Cannot find module .*\/lib\/binding\/electron-v1.2-[^-]+-x64\/node_sqlite3.node/));
+                  (/Cannot find module .*\/lib\/binding\/electron-v1.2-[^-]+-x64\/node_sqlite3.node/),
+                  "Should have error like 'cannot find module'");
   });
 });

--- a/test/electron.test.js
+++ b/test/electron.test.js
@@ -4,6 +4,6 @@ describe('electron', function() {
   it('respects ELECTRON_VERSION', function() {
     process.env.ELECTRON_VERSION = '1.2.3';
     assert.throws(function() { require('..'); },
-                  (/Cannot find module .*\/node-sqlite3\/lib\/binding\/electron-v1.2-[^-]+-x64\/node_sqlite3.node/));
+                  (/Cannot find module .*\/lib\/binding\/electron-v1.2-[^-]+-x64\/node_sqlite3.node/));
   });
 });


### PR DESCRIPTION
marshal.node was failing to link on linux (built from test/cpp/binding.gyp for marshal-test.js)
Electron test only worked if repo was checked out as exactly node-sqlite3.