### PR TITLE
Fix bug in allMarshal() with ints that don't fit in 32 bits.

### DIFF
--- a/src/statement.cc
+++ b/src/statement.cc
@@ -614,9 +614,16 @@ void Statement::Work_AllMarshal(uv_work_t* req) {
           for (int i = 0; i < columns; i++) {
             int type = sqlite3_column_type(sqstmt, i);
             switch (type) {
-                case SQLITE_INTEGER:
-                    baton->colData[i].marshalInt(sqlite3_column_int64(sqstmt, i));
+                case SQLITE_INTEGER: {
+                    int64_t value = sqlite3_column_int64(sqstmt, i);
+                    int32_t smallValue = int32_t(value);
+                    if (value == smallValue) {
+                      baton->colData[i].marshalInt(smallValue);
+                    } else {
+                      baton->colData[i].marshalDouble(value);
+                    }
                     break;
+                }
                 case SQLITE_FLOAT:
                     baton->colData[i].marshalDouble(sqlite3_column_double(sqstmt, i));
                     break;

--- a/test/allMarshal.test.js
+++ b/test/allMarshal.test.js
@@ -1,0 +1,64 @@
+/* globals describe, it, before, after */
+var sqlite3 = require('..');
+var assert = require('assert');
+
+describe('Database#allMarshal', function() {
+    var db;
+    before(function(done) { db = new sqlite3.Database(':memory:', done); });
+
+    var testValues = [0x7FFFFFFF, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER + 1];
+    var marshalled = ['i\xff\xff\xff\x7f', 'g\xff\xff\xff\xff\xff\xff?C', 'g\x00\x00\x00\x00\x00\x00@C'];
+    var marshalledFloat = ['g\x00\x00\xc0\xff\xff\xff\xdfA', marshalled[1], marshalled[2]];
+
+    it('should create the table', function(done) {
+        db.run("CREATE TABLE foo (row text, num int, flt float, blb blob)", function(err) {
+            if (err) throw err;
+            var inserted = 0;
+            for (var i = 0; i < testValues.length; i++) {
+                var val = testValues[i];
+                db.run("INSERT INTO foo VALUES(?, ?, ?, ?)",
+                    'row' + i, val, val, val,
+                    function(err) {
+                        if (err) throw err;
+                        inserted++;
+                        if (inserted === testValues.length) {
+                            done();
+                        }
+                    }
+                );
+            }
+        });
+    });
+
+    it('should retrieve all rows', function(done) {
+        var fields = ['num', 'flt', 'blb'];
+        var count = 0;
+        var results = [];
+        testValues.forEach(function(value, i) {
+            results[i] = {};
+            fields.forEach(function(field) {
+                count++;
+                db.allMarshal("SELECT " + field + " as f FROM foo WHERE row=\"row" + i + "\"",
+                  function(err, result) {
+                      results[i][field] = result;
+                      if (--count === 0) { compare(); }
+                  }
+                );
+            });
+        });
+        function compare() {
+            testValues.forEach(function(value, i) {
+                fields.forEach(function(field) {
+                    // We query in a way so that marshalled data has the same form for all values:
+                    var mvalue = (field === 'flt') ? marshalledFloat[i] : marshalled[i];
+                    var expect = Buffer.from('{s\x01\x00\x00\x00f[\x01\x00\x00\x00' + mvalue + '0', 'binary');
+                    var result = results[i][field];
+                    assert.deepEqual(result, expect);
+                });
+            });
+            done();
+        }
+    });
+
+    after(function(done) { db.close(done); });
+});

--- a/test/marshal-test.js
+++ b/test/marshal-test.js
@@ -31,6 +31,10 @@ describe('marshal', function() {
       '{u\x04\x00\x00\x00Thisi\x04\x00\x00\x00u\x01\x00\x00\x00as\x04\x00\x00\x00testu\x02\x00\x00\x00isi\x00\x00\x00\x000'],
     // Limits of 32-bit integers.
     [[0x7FFFFFFF, -0x80000000], '[\x02\x00\x00\x00i\xff\xff\xff\x7fi\x00\x00\x00\x80'],
+    // Beyond 32-bit limit, we marshal numbers as doubles.
+    [0x80000000, 'g\x00\x00\x00\x00\x00\x00\xe0A'],
+    [-9007199254740991, 'g\xff\xff\xff\xff\xff\xff?\xc3'],
+    [9007199254740992, 'g\x00\x00\x00\x00\x00\x00@C'],
   ];
 
   it("should serialize correctly", function() {


### PR DESCRIPTION
Now will marshal them as doubles. Includes a test case that fails without the fix.