### PR TITLE
turn off support for ATTACH

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -88,7 +88,8 @@
           'SQLITE_ENABLE_FTS4',
           'SQLITE_ENABLE_FTS5',
           'SQLITE_ENABLE_JSON1',
-          'SQLITE_ENABLE_RTREE'
+          'SQLITE_ENABLE_RTREE',
+          'SQLITE_MAX_ATTACHED=0'
         ],
       },
       'cflags_cc': [
@@ -102,7 +103,8 @@
         'SQLITE_ENABLE_FTS4',
         'SQLITE_ENABLE_FTS5',
         'SQLITE_ENABLE_JSON1',
-        'SQLITE_ENABLE_RTREE'
+        'SQLITE_ENABLE_RTREE',
+        'SQLITE_MAX_ATTACHED=0'
       ],
       'export_dependent_settings': [
         'action_before_build',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gristlabs/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "4.1.1-grist.1",
+  "version": "4.1.1-grist.2",
   "homepage": "https://github.com/mapbox/node-sqlite3",
   "author": {
     "name": "MapBox",

--- a/test/attach.test.js
+++ b/test/attach.test.js
@@ -1,0 +1,24 @@
+var sqlite3 = require('..');
+var helper = require('./support/helper');
+
+describe('attach', function() {
+  // Check that ATTACH is not supported, as part of defense in depth measures.
+  it ('does not permit attaching another db', function(done) {
+    helper.deleteFile('test/tmp/test1.db');
+    helper.deleteFile('test/tmp/test2.db');
+    var db = new sqlite3.Database('test/tmp/test1.db', function(err) {
+      if (err) throw err;
+      db.exec("ATTACH 'test/support/prepare.db' AS zing", function (err) {
+        if (!err) {
+          throw new Error('ATTACH should not succeed');
+        }
+        if (err.errno === sqlite3.ERROR &&
+            err.message === 'SQLITE_ERROR: too many attached databases - max 0') {
+          db.close(done);
+        } else {
+          throw err;
+        }
+      });
+    });
+  });
+});

--- a/test/attach.test.js
+++ b/test/attach.test.js
@@ -4,9 +4,8 @@ var helper = require('./support/helper');
 describe('attach', function() {
   // Check that ATTACH is not supported, as part of defense in depth measures.
   it ('does not permit attaching another db', function(done) {
-    helper.deleteFile('test/tmp/test1.db');
-    helper.deleteFile('test/tmp/test2.db');
-    var db = new sqlite3.Database('test/tmp/test1.db', function(err) {
+    helper.deleteFile('test/tmp/test_attach.db');
+    var db = new sqlite3.Database('test/tmp/test_attach.db', function(err) {
       if (err) throw err;
       db.exec("ATTACH 'test/support/prepare.db' AS zing", function (err) {
         if (!err) {


### PR DESCRIPTION
This sets the maximum number of ATTACHed databases to 0, as suggested by https://www.sqlite.org/security.html

For further steps, I'm now planning to switch to better-sqlite3 first.