### PR TITLE
fix memory leak in allMarshal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gristlabs/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "5.1.4-grist.7",
+  "version": "5.1.4-grist.8",
   "homepage": "https://github.com/gristlabs/node-sqlite3",
   "author": {
     "name": "Mapbox",
@@ -74,7 +74,7 @@
     "install": "node-pre-gyp install --fallback-to-build",
     "pretest": "node test/support/createdb.js",
     "test": "mocha -R spec --timeout 480000",
-    "rebuild-tests": "node-gyp rebuild --directory test/cpp",
+    "test:memory": "node test/support/memory_check.js",
     "pack": "node-pre-gyp package"
   },
   "license": "BSD-3-Clause",

--- a/test/support/memory_check.js
+++ b/test/support/memory_check.js
@@ -1,0 +1,32 @@
+/**
+ * A quick test for memory leakage.
+ * Run as "npm run test:memory".
+ * Reports a loop count and a free memory number. If the free memory
+ * number drops precipitously, uh-oh. Memory reported is for full system,
+ * so don't do too much in background while this runs.
+ */
+
+const sqlite3 = require('../..');
+const util = require('util');
+const os = require('os');
+
+async function run() {
+  const db = new sqlite3.Database(':memory:');
+  const run = util.promisify(db.run.bind(db));
+  const fetch = util.promisify(db.allMarshal.bind(db));
+  console.log('Creating table');
+  await run('CREATE TABLE foo (row text, blb blob)');
+  for (let i = 0; i < 10000; i++) {
+    await run('INSERT INTO foo VALUES(?, ?)',
+              'row ' + i, 'g\x00\x00\xc0\xff\xff\xff\xdfA');
+  }
+  console.log('Running queries');
+  for (let i = 0; i < 100000; i++) {
+    if (i % 1000 === 0) {
+      console.log(String(i).padStart(20), String(os.freemem()).padStart(20));
+    }
+    await fetch('SELECT * FROM foo');
+  }
+}
+
+run().catch(e => console.log(e));


### PR DESCRIPTION
Changes the implementation of `allMarshal` to follow closely the evolution of the implementation of `all`.

Adds a script that can be run as `npm run test:memory` to check for obvious memory leaks.

Prior to this fix, a typical run looked like (loop count, free memory):
```
                   0           8081154048
                1000           7443259392
                2000           6777753600
                3000           6128287744
                4000           5500166144
                5000           4849360896
                6000           4221939712
                7000           3558346752
                8000           2960449536
                9000           2309222400
               10000           1655738368
               11000           1019441152
```

After this fix, a typical run looks like:
```
                   0           8291295232
                1000           8268148736
                2000           8252329984
                3000           8253804544
                4000           8252588032
                5000           8261718016
                6000           8248782848
                7000           8268709888
                8000           8249749504
                9000           8258523136
               10000           8242008064
               11000           8255168512
```