### PR TITLE
actions: update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,15 @@ jobs:
         target:
           - x64
         node:
-          - 14
-          - 16
-          - 18
+          - 22
         include:
           - os: windows-latest
-            node: 16
+            node: 22
             host: x86
             target: x86
           # This is a self-hosted runner, github doesn't have this architecture yet.
           - os: macos-m1
-            node: 16
+            node: 22
             host: arm64
             target: arm64
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
@@ -110,7 +108,6 @@ jobs:
 
       - name: Upload binaries to commit artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.node == 16
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: build/stage/*/*
@@ -118,7 +115,7 @@ jobs:
 
       - name: Upload binaries to GitHub Release
         run: yarn node-pre-gyp-github publish
-        if: matrix.node == 16 && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           NODE_PRE_GYP_GITHUB_TOKEN: ${{ github.token }}
   build-qemu:
@@ -128,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 16
+          - 22
         target:
           - linux/arm64
         variant:
@@ -138,7 +135,6 @@ jobs:
           # musl x64 builds
           - target: linux/amd64
             variant: alpine3.15
-            node: 16
     name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v3
@@ -172,7 +168,6 @@ jobs:
 
       - name: Upload binaries to commit artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.node == 16
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: build/stage/*/*
@@ -180,6 +175,6 @@ jobs:
 
       - name: Upload binaries to GitHub Release
         run: yarn install --ignore-scripts && yarn node-pre-gyp-github publish
-        if: matrix.node == 16 && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           NODE_PRE_GYP_GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,12 +128,10 @@ jobs:
           - 22
         target:
           - linux/arm64
+          - linux/amd64
         variant:
-          - bullseye
+          - bookworm
           - alpine
-        include:
-          # musl x64 builds
-          - target: linux/amd64
     name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,18 @@ jobs:
       - name: Package prebuilt binaries
         run: yarn node-pre-gyp package --target_arch=${{ env.TARGET }}
 
+      - name: Prepare for saving artifact
+        run: |
+          ARTIFACT_NAME=$(echo prebuilt-binaries-${{ matrix.os }}-${{ matrix.target }} | sed 's/[^-a-zA-Z0-9]/_/g')
+          echo "Artifact name is '$ARTIFACT_NAME'"
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+        shell: bash
+
       - name: Upload binaries to commit artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.node == 16
         with:
-          name: prebuilt-binaries
+          name: ${{ env.ARTIFACT_NAME }}
           path: build/stage/*/*
           retention-days: 7
 
@@ -156,11 +163,18 @@ jobs:
           CONTAINER_ID=$(docker create -it sqlite-builder)
           docker cp $CONTAINER_ID:/usr/src/build/build/ ./build
 
+      - name: Prepare for saving artifact
+        run: |
+          ARTIFACT_NAME=$(echo prebuilt-binaries-${{ matrix.variant }}-${{ matrix.target }} | sed 's/[^-a-zA-Z0-9]/_/g')
+          echo "Artifact name is '$ARTIFACT_NAME'"
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+        shell: bash
+
       - name: Upload binaries to commit artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.node == 16
         with:
-          name: prebuilt-binaries
+          name: ${{ env.ARTIFACT_NAME }}
           path: build/stage/*/*
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,10 @@ jobs:
           - linux/arm64
         variant:
           - bullseye
-          - alpine3.15
+          - alpine
         include:
           # musl x64 builds
           - target: linux/amd64
-            variant: alpine3.15
     name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-24.04
           - windows-latest
         host:
           - x64

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node-pre-gyp-github": "1.4.4"
   },
   "peerDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": "11.x"
   },
   "peerDependenciesMeta": {
     "node-gyp": {
@@ -66,7 +66,7 @@
     }
   },
   "optionalDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": "11.x"
   },
   "scripts": {
     "build": "node-pre-gyp build",


### PR DESCRIPTION
v3 is scheduled for removal at the end of this month.

Tested that these changes [produce a clean run](https://github.com/gristlabs/node-sqlite3/actions/runs/12702943296/job/35409932707).