### PR TITLE
fix bad behavior in marshal for empty buffers/strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
             node: 22
             host: x86
             target: x86
-          # This is a self-hosted runner, github doesn't have this architecture yet.
-          - os: macos-m1
+          - os: macos-latest
             node: 22
             host: arm64
             target: arm64
@@ -47,10 +46,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.host }}
-
-      - name: Add yarn (self-hosted)
-        if: matrix.os == 'macos-m1'
-        run: npm install -g yarn
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
       - name: Package prebuilt binaries
         run: yarn node-pre-gyp package --target_arch=${{ env.TARGET }}
 
+      - name: Rebuild with assertions and re-test
+        if: contains(matrix.os, 'ubuntu')
+        run: yarn build:assert && yarn test
+
       - name: Prepare for saving artifact
         run: |
           ARTIFACT_NAME=$(echo prebuilt-binaries-${{ matrix.os }}-${{ matrix.target }} | sed 's/[^-a-zA-Z0-9]/_/g')

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "build": "node-pre-gyp build",
     "build:debug": "node-pre-gyp build --debug",
     "install": "node-pre-gyp install --fallback-to-build",
+    "build:assert": "CXXFLAGS=\"${CXXFLAGS:-} -D_GLIBCXX_ASSERTIONS\" node-pre-gyp rebuild --build-from-source",
     "pretest": "node test/support/createdb.js",
     "test": "mocha -R spec --timeout 480000",
     "test:memory": "node test/support/memory_check.js",

--- a/src/marshal.h
+++ b/src/marshal.h
@@ -38,6 +38,7 @@ class Marshaller {
     }
 
     void _writeBytes(const void *bytes, size_t nbytes) {
+      if (nbytes == 0) return;
       size_t offset = buffer.size();
       buffer.resize(buffer.size() + nbytes);
       memcpy(&buffer[offset], bytes, nbytes);
@@ -57,7 +58,7 @@ class Marshaller {
 
     void append(const Marshaller &marshaller) {
       const std::vector<char> &buf = marshaller.getBuffer();
-      _writeBytes(&buf[0], buf.size());
+      _writeBytes(buf.data(), buf.size());
     }
 
     // Marshal the given value depending on its type.
@@ -68,7 +69,7 @@ class Marshaller {
     }
 
     void marshalString(const std::string &value) {
-      marshalString(&value[0], value.size());
+      marshalString(value.data(), value.size());
     }
 
     void marshalString(const char *value, int32_t size) {

--- a/test/allMarshal.test.js
+++ b/test/allMarshal.test.js
@@ -60,5 +60,34 @@ describe('Database#allMarshal', function() {
         }
     });
 
+    it('should handle empty result set', function(done) {
+        db.allMarshal("SELECT * FROM foo WHERE 1=0", function(err, result) {
+            if (err) throw err;
+            // Should be a dict with column names mapping to empty lists:
+            // {s<col>[\x00\x00\x00\x00 ...} for each column, terminated by '0'
+            assert.ok(Buffer.isBuffer(result));
+            var parsed = sqlite3.parse(result);
+            assert.deepEqual(parsed, {row: [], num: [], flt: [], blb: []});
+            done();
+        });
+    });
+
+    it('should handle empty string and blob values', function(done) {
+        db.run("CREATE TABLE bar (txt text, blb blob)", function(err) {
+            if (err) throw err;
+            db.run("INSERT INTO bar VALUES('', X'')", function(err) {
+                if (err) throw err;
+                db.allMarshal("SELECT * FROM bar", function(err, result) {
+                    if (err) throw err;
+                    assert.ok(Buffer.isBuffer(result));
+                    var parsed = sqlite3.parse(result);
+                    assert.deepEqual(parsed.txt, ['']);
+                    assert.deepEqual(parsed.blb, [new Uint8Array(0)]);
+                    done();
+                });
+            });
+        });
+    });
+
     after(function(done) { db.close(done); });
 });

--- a/test/marshal-test.js
+++ b/test/marshal-test.js
@@ -10,6 +10,9 @@ describe('marshal', function() {
     return new Uint8Array(Buffer.from(str));
   }
   const samples = [
+    // Empty string and empty buffer exercise _writeBytes with 0 bytes.
+    ['', 'u\x00\x00\x00\x00'],
+    [new Uint8Array(0), 's\x00\x00\x00\x00'],
     [null, 'N'],
     [1, 'i\x01\x00\x00\x00'],
     [1000000, 'i@B\x0f\x00'],


### PR DESCRIPTION
When built with _GLIBCXX_ASSERTIONS (as in Flatpak environments), allMarshal crashes on empty result sets or empty string/blob values due to out-of-bounds vector/string access via operator[]. Fix by using .data() and guarding _writeBytes against zero-length writes.

Add tests for empty result sets, empty strings, and empty blobs. Add build:assert script and CI step to catch this class of bug.